### PR TITLE
Do not log error when mounting unsupported fs type

### DIFF
--- a/init.c
+++ b/init.c
@@ -90,7 +90,8 @@ si_mount(const char *src, const char *dst, const char *type,
 {
     mkdir(dst, 0755);
 
-    if (mount(src, dst, type, flags, data))
+    if (mount(src, dst, type, flags, data) == -1 &&
+            errno != ENODEV && errno != ENOENT)
         si_log(si_critical, "mount(%s): %m", dst);
 }
 


### PR DESCRIPTION
See https://github.com/angt/slashinit/issues/1